### PR TITLE
add case insensitive string literal comparison

### DIFF
--- a/pypred/ast.py
+++ b/pypred/ast.py
@@ -264,7 +264,8 @@ class CompareOperator(Node):
     def _check_insensitive_equal(self, eleft, eright):
         """
         Check use the first InsensitiveLiteral to evaluate the
-        evaluated other
+        evaluated other.
+        `eleft` and `eright` are the ctx evaluated values.
         """
         if isinstance(self.left, InsensitiveLiteral):
             return True, self.left == eright
@@ -881,3 +882,4 @@ class LiteralSet(Node):
                 v = i.value
             s.add(v)
         return frozenset(s)
+

--- a/pypred/grammer.txt
+++ b/pypred/grammer.txt
@@ -24,3 +24,4 @@ factor : NUMBER
        | NULL
        | EMPTY
        | LPAREN expression RPAREN
+

--- a/pypred/merge.py
+++ b/pypred/merge.py
@@ -391,3 +391,4 @@ def count_patterns():
 
     CACHE_PATTERNS = [p1,p2,p3,p4,p5,p6]
     return CACHE_PATTERNS
+

--- a/pypred/parser.py
+++ b/pypred/parser.py
@@ -74,7 +74,6 @@ def t_NUMBER(t):
 
 # Matches anything that is literal `i` prefix quoted
 def t_CASE_INSENSITIVE_STRING(t):
-    # r'("[^"]*"|\'[^\']*\')'
     r'i"(.*?)"|i\'(.*?)\''
     # Check for reserved words
     t.type = reserved.get(t.value,'CASE_INSENSITIVE_STRING')
@@ -251,3 +250,4 @@ def get_parser(lexer=None, debug=0):
         lexer.parser = p
         p.lexer = lexer
     return p
+

--- a/pypred/predicate.py
+++ b/pypred/predicate.py
@@ -220,3 +220,4 @@ class Predicate(LiteralResolver):
         if not self.is_valid():
             raise InvalidPredicate
         return self.ast.analyze(self, document)
+


### PR DESCRIPTION
I'd like to be able to have predicates that compare case insensitive strings so that I can have a predicate, `hashtag is i'#lol' and username is i'stuntgoat'` and a document `{'username': 'Stuntgoat', 'hashtag': '#LoL'}` evaluate `True`

If this is on the right track, I'll write some tests.
