### PR TITLE
Py3.5 support, pypi fixes + testing on multiple versions of python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 *.py[co]
 env
 build
+.cache
+.coverage
+.pyenv
+.tox
 
 # Ignore the parser outputs
 parsetab.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
 language: python
 python:
-  - "2.7"
+  - 2.7
+  - 3.4
+  - 3.5
+  - pypy
 before_install:
   - sudo apt-get -y install wamerican
-script: py.test tests/ && python bench.py
+install:
+  - pip install -r requirements.txt
+script:
+  - coverage run --branch --source=pypred -m py.test tests/
+  - python bench.py
+  - coverage report -m

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.4.0
+* Python3 support
+* Added support for `==` operator
+* Permit unicode in predicates
+* Support for case insensitive operators
+* Tested on python 2.7, 3.4, 3.5 & pypy
+* SHA: 
+
 ## 0.3.6
 
 * Improve the optimization of LiteralSet by making sets as small as possible,

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-PyPred [![Build Status](https://travis-ci.org/armon/pypred.png)](https://travis-ci.org/armon/pypred)
+PyPred
 ======
+[![Build Status](https://travis-ci.org/armon/pypred.png)](https://travis-ci.org/armon/pypred)
 
 PyPred is a package to do predicate evaluation in Python. It uses a
 PLY (Lex/Yacc for Python) to parse inputs into an AST tree which it
@@ -117,8 +118,8 @@ The OptimizedPredicateSet supports an extended set of API's:
 * OptSet.compile\_ast() : Forces compilation of the interal AST
 
 * OptSet.finalize() : Prunes the AST of sub-predicates, and removes any instance data that is not used
-as part of the evaluation of the optimized set. Not usually needed, but can reduce the total memory
-footprint, and is useful if the object is going to be pickled.
+  as part of the evaluation of the optimized set. Not usually needed, but can reduce the total memory
+  footprint, and is useful if the object is going to be pickled.
 
 The standard PredicateSet relies on the underlying predicates to do
 resolution of literals, however the OptimizedPredicateSet implements
@@ -155,9 +156,9 @@ Here is an example of the output during a failed evaluation:
     assert res == False
 
     pprint.pprint(ctx.failed)
-    ["Right side: 'CPU load' not in left side: [] for ContainsOperator at line: 1, col 45",
-                'Left hand side of AND operator at line: 1, col 65 failed',
-                'Right hand side of AND operator at line: 1, col 34 failed']
+     ["Right side: 'CPU load' not in left side: [] for ContainsOperator at line: 1, col 45",
+                 'Left hand side of AND operator at line: 1, col 65 failed',
+                 'Right hand side of AND operator at line: 1, col 34 failed']
 
     pprint.pprint(ctx.literals)
      {'"CPU load"': 'CPU load',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
-ply==3.4
-pytest==2.3.4
-mock==1.0.1
+ply==3.8
+pytest==2.9.2
+mock==2.0.0
+coverage==4.2
+pbr==1.10.0
+py==1.4.31
+six==1.10.0

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from setuptools import setup
-__version__ = "0.3.6"
+__version__ = "0.4.0"
 
 # Get the long description by reading the README
 try:

--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,5 @@ setup(name='pypred',
         "Programming Language :: Python",
         "Topic :: Software Development :: Libraries"
       ],
-      install_requires=["ply==3.4"]
+      install_requires=["ply>=3.4"]
     )

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,10 @@ setup(name='pypred',
         "License :: OSI Approved :: MIT License",
         "Operating System :: POSIX",
         "Programming Language :: Python",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
         "Topic :: Software Development :: Libraries"
       ],
       install_requires=["ply>=3.4"]

--- a/tests/unit/test_ast.py
+++ b/tests/unit/test_ast.py
@@ -52,7 +52,8 @@ class TestAST(object):
         assert not valid
         assert "Compilation failed" in info["errors"][0]
         assert "(abc" in info["regex"]
-        assert info["regex"]["(abc"] == "unbalanced parenthesis"
+        assert info["regex"]["(abc"] == "unbalanced parenthesis" or\
+               info["regex"]["(abc"].startswith("missing ), unterminated subpattern")
 
     def test_bad_regex_inp(self):
         a = self.ast("foo matches '(abc'")
@@ -60,7 +61,8 @@ class TestAST(object):
         assert not valid
         assert "Compilation failed" in info["errors"][0]
         assert "(abc" in info["regex"]
-        assert info["regex"]["(abc"] == "unbalanced parenthesis"
+        assert info["regex"]["(abc"] == "unbalanced parenthesis" or\
+               info["regex"]["(abc"].startswith("missing ), unterminated subpattern")
 
     def test_match_bad_arg(self):
         a = ast.MatchOperator(ast.Literal("foo"), ast.Literal("bar"))

--- a/tests/unit/test_predicate.py
+++ b/tests/unit/test_predicate.py
@@ -39,7 +39,8 @@ class TestPredicate(object):
         assert not p.is_valid()
         errs = p.errors()
         assert 'Compilation failed for' in errs["errors"][0]
-        assert 'unbalanced parenthesis' == errs["regex"]["(unbal"]
+        assert 'unbalanced parenthesis' == errs["regex"]["(unbal"] or\
+               errs["regex"]["(unbal"].startswith("missing ), unterminated subpattern")
 
     def test_resolve_missing(self):
         p = Predicate("name is 'Jack' and friend is 'Jill'")

--- a/tox.ini
+++ b/tox.ini
@@ -14,9 +14,12 @@ commands = rm -fR {toxinidir}/.coverage
 
 [testenv:report]
 skip_install = True
-deps = coverage
+deps = 
+    coverage
+    docutils
 commands =
     - coverage report -m
+    - python setup.py check -mrs
 
 [testenv]
 deps = -rrequirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,27 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = erase, py27, pypy, py34, py35, report
+
+[testenv:erase]
+skip_install = True
+deps =
+whitelist_externals = rm
+commands = rm -fR {toxinidir}/.coverage
+
+[testenv:report]
+skip_install = True
+deps = coverage
+commands =
+    - coverage report -m
+
+[testenv]
+deps = -rrequirements.txt
+whitelist_externals = false
+commands =
+    coverage run -a --branch --source=pypred -m py.test tests/
+    python bench.py
+


### PR DESCRIPTION
Hi

I fixed tests on Python3.5 (there was a change on the regex error reports only), updated dependencies to latest stable, fixed README.md so that it will parse correctly on pypi, added classifiers for tested python versions, and both a local tox and travis config to run tests on python2.7,3.4,3.5 and pypy.

I bumped the version and updated the Changelog as a courtesy.

Hope this is all in order,
Regards

Would love it if you could deploy on PyPi :+1: 