### PR TITLE
Allow resolver callback to resolve from document

### DIFF
--- a/pypred/predicate.py
+++ b/pypred/predicate.py
@@ -72,7 +72,7 @@ class LiteralResolver(object):
         if identifier in self.resolvers:
             relv = self.resolvers[identifier]
             if isinstance(relv, collections.Callable):
-                return relv()
+                return relv(document)
             else:
                 return relv
 


### PR DESCRIPTION
Adds the document to the resolve callback in order to allow a callback to create identifiers from the document, not just from the predicate.

Example use case: document has datetime.date objects, but predicate is meant to allow to resolve "age > 50".